### PR TITLE
Update README.md com a anotação @AutoConfigureTestDatabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@
 >*injeta o objeto MockMvc no contexto da aplicação para testes de integração.*
 - @AutoConfigureJsonTesters:
 >*habilita e configura automaticamente os testadores de JSON para os testes.*
+- @AutoConfigureTestDatabase:
+>*utilizada para configurar um database de teste que substitui o DataSource definido pela aplicação ou automaticamente configurado para fins de testes.*
 - @AssertTrue:
 >*indica que o valor booleano que está sendo testado deve ser verdadeiro para que o teste seja considerado bem-sucedido.*
 


### PR DESCRIPTION
A notação pode ser utilizada para configurar um banco de dados de teste que substitui o DataSource definido pela aplicação ou automaticamente configurado para fins de testes.

Um exemplo é quando estamos testando a camada de repository, utilizando o @DataJpaTest ele vai subir uma instância em memória do H2 database. Para utilizarmos um banco de dados real em um container por exemplo, usamos essa annotation para dizer que o banco que será utilizado no teste será o apontado no DataSource (application.properties ou .yml)

[Link para Doc da anotação](https://docs.spring.io/spring-boot/api/java/org/springframework/boot/test/autoconfigure/jdbc/AutoConfigureTestDatabase.html)